### PR TITLE
remove push to git step in automations

### DIFF
--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: git config --global user.name 'Ziemniakoss' && git config --global user.email 'Ziemniakoss@users.noreply.github.com'
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
@@ -21,5 +20,3 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}
-      - name: Update git repo
-        run: git push --follow-tags origin HEAD

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: git config --global user.name 'Ziemniakoss' && git config --global user.email 'Ziemniakoss@users.noreply.github.com'
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
@@ -21,5 +20,3 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}
-      - name: Update git repo
-        run: git push --follow-tags origin HEAD

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: git config --global user.name 'Ziemniakoss' && git config --global user.email 'Ziemniakoss@users.noreply.github.com'
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
@@ -21,5 +20,3 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}
-      - name: Update git repo
-        run: git push --follow-tags origin HEAD


### PR DESCRIPTION
Pushing to master in git is prohibited and tags are uploaded anyway so we can just remove this step